### PR TITLE
Fix Azure subscription name in azure-build-and-release-pipeline.yml

### DIFF
--- a/azure/ARMTemplates/Pipelines/azure-build-and-release-pipeline.yml
+++ b/azure/ARMTemplates/Pipelines/azure-build-and-release-pipeline.yml
@@ -187,7 +187,7 @@ stages:
                 - task: AzureAppServiceManage@0
                   displayName: ''
                   inputs:
-                    azureSubscription: 'AAzure Xebia MPN Subscription | Service Principal'
+                    azureSubscription: 'Azure Xebia MPN Subscription | Service Principal'
                     Action: 'Swap Slots'
                     WebAppName: '$(AppServiceName)'
                     ResourceGroupName: '$(AppServiceResourceGroup)'


### PR DESCRIPTION
This pull request includes a minor change to the `azure-build-and-release-pipeline.yml` file. The change corrects the name of the Azure subscription from 'AAzure Xebia MPN Subscription | Service Principal' to 'Azure Xebia MPN Subscription | Service Principal'.