### PR TITLE
Updated Azure build pipeline variable values

### DIFF
--- a/azure/pipelines/azure-build-and-release-pipeline.yml
+++ b/azure/pipelines/azure-build-and-release-pipeline.yml
@@ -36,6 +36,10 @@ variables:
     value: '233779e9-4d8e-43ab-8c13-36b86d4386ca'
     readonly: true
 
+  - name: AzureServicePrincipalName
+    value: 'Azure Allen MVP Subscription | Service Principal'
+    readonly: true
+
   - name: AppServiceName 
     value: 'PWAWeatherApp' 
     readonly: true
@@ -51,7 +55,6 @@ variables:
   - name: AzureLocation
     value: 'eastus'
     readonly: true
-
 
 stages:
   - stage: Build
@@ -110,7 +113,7 @@ stages:
                 - task: AzureCLI@2
                   displayName: 'Azure CLI: Provision Resource Groups'
                   inputs:
-                    azureSubscription: 'Azure Xebia MPN Subscription | Service Principal'
+                    azureSubscription: '$(AzureServicePrincipalName)'
                     scriptType: 'pscore'
                     scriptLocation: 'inlineScript'
                     inlineScript: |
@@ -119,7 +122,7 @@ stages:
                 - task: AzureResourceManagerTemplateDeployment@3
                   displayName: 'Azure ARM Template Deploy: Provision App Service'
                   inputs:
-                    azureResourceManagerConnection: 'Azure Xebia MPN Subscription | Service Principal'
+                    azureResourceManagerConnection: '$(AzureServicePrincipalName)'
                     subscriptionId: '$(AzureSubscriptionId)'
                     resourceGroupName: '$(AppServiceResourceGroup)'
                     location: 'East US'
@@ -139,7 +142,7 @@ stages:
                 steps:
                 - task: AzureWebApp@1
                   inputs:
-                    azureSubscription: 'Azure Xebia MPN Subscription | Service Principal'
+                    azureSubscription: '$(AzureServicePrincipalName)'
                     appType: 'webAppLinux'
                     appName: '$(AppServiceName)'
                     deployToSlotOrASE: true
@@ -159,7 +162,7 @@ stages:
                 steps:
                 - task: AzureWebApp@1
                   inputs:
-                    azureSubscription: 'Azure Xebia MPN Subscription | Service Principal'
+                    azureSubscription: '$(AzureServicePrincipalName)'
                     appType: 'webAppLinux'
                     appName: '$(AppServiceName)'
                     deployToSlotOrASE: true
@@ -179,7 +182,7 @@ stages:
                 steps:
                 - task: AzureWebApp@1
                   inputs:
-                    azureSubscription: 'Azure Xebia MPN Subscription | Service Principal'
+                    azureSubscription: '$(AzureServicePrincipalName)'
                     appType: 'webAppLinux'
                     appName: '$(AppServiceName)'
                     deployToSlotOrASE: true
@@ -200,7 +203,7 @@ stages:
                 - task: AzureAppServiceManage@0
                   displayName: ''
                   inputs:
-                    azureSubscription: 'Azure Xebia MPN Subscription | Service Principal'
+                    azureSubscription: '$(AzureServicePrincipalName)'
                     Action: 'Swap Slots'
                     WebAppName: '$(AppServiceName)'
                     ResourceGroupName: '$(AppServiceResourceGroup)'


### PR DESCRIPTION
This pull request includes changes to the `azure/pipelines/azure-build-and-release-pipeline.yml` file. The primary change is the introduction of a new variable `AzureServicePrincipalName`, and the replacement of the hardcoded `azureSubscription` and `azureResourceManagerConnection` values with this new variable. This change makes the script more flexible and maintainable by centralizing the service principal name.

Variable changes:

* [`azure/pipelines/azure-build-and-release-pipeline.yml`](diffhunk://#diff-c042c5cc9bcfa797e88d18cf420bdcae1385306878dba835ecea536b5a8fbcd3R39-R42): Added a new variable `AzureServicePrincipalName` and removed an unnecessary line. [[1]](diffhunk://#diff-c042c5cc9bcfa797e88d18cf420bdcae1385306878dba835ecea536b5a8fbcd3R39-R42) [[2]](diffhunk://#diff-c042c5cc9bcfa797e88d18cf420bdcae1385306878dba835ecea536b5a8fbcd3L55)

Subscription and connection changes:

* [`azure/pipelines/azure-build-and-release-pipeline.yml`](diffhunk://#diff-c042c5cc9bcfa797e88d18cf420bdcae1385306878dba835ecea536b5a8fbcd3L113-R116): Replaced hardcoded `azureSubscription` and `azureResourceManagerConnection` values with `$(AzureServicePrincipalName)` in multiple stages. [[1]](diffhunk://#diff-c042c5cc9bcfa797e88d18cf420bdcae1385306878dba835ecea536b5a8fbcd3L113-R116) [[2]](diffhunk://#diff-c042c5cc9bcfa797e88d18cf420bdcae1385306878dba835ecea536b5a8fbcd3L122-R125) [[3]](diffhunk://#diff-c042c5cc9bcfa797e88d18cf420bdcae1385306878dba835ecea536b5a8fbcd3L142-R145) [[4]](diffhunk://#diff-c042c5cc9bcfa797e88d18cf420bdcae1385306878dba835ecea536b5a8fbcd3L162-R165) [[5]](diffhunk://#diff-c042c5cc9bcfa797e88d18cf420bdcae1385306878dba835ecea536b5a8fbcd3L182-R185) [[6]](diffhunk://#diff-c042c5cc9bcfa797e88d18cf420bdcae1385306878dba835ecea536b5a8fbcd3L203-R206)