### PR TITLE
Updated Azure Service Connection variable in YAML pipeline

### DIFF
--- a/azure/pipelines/azure-build-and-release-pipeline.yml
+++ b/azure/pipelines/azure-build-and-release-pipeline.yml
@@ -36,8 +36,8 @@ variables:
     value: '233779e9-4d8e-43ab-8c13-36b86d4386ca'
     readonly: true
 
-  - name: AzureServicePrincipalName
-    value: 'Azure Allen MVP Subscription | Service Principal'
+  - name: AzureServiceConnectionName
+    value: 'Azure Allen MVP Subscription | Service Connection'
     readonly: true
 
   - name: AppServiceName 
@@ -113,7 +113,7 @@ stages:
                 - task: AzureCLI@2
                   displayName: 'Azure CLI: Provision Resource Groups'
                   inputs:
-                    azureSubscription: '$(AzureServicePrincipalName)'
+                    azureSubscription: '$(AzureServiceConnectionName)'
                     scriptType: 'pscore'
                     scriptLocation: 'inlineScript'
                     inlineScript: |
@@ -122,7 +122,7 @@ stages:
                 - task: AzureResourceManagerTemplateDeployment@3
                   displayName: 'Azure ARM Template Deploy: Provision App Service'
                   inputs:
-                    azureResourceManagerConnection: '$(AzureServicePrincipalName)'
+                    azureResourceManagerConnection: '$(AzureServiceConnectionName)'
                     subscriptionId: '$(AzureSubscriptionId)'
                     resourceGroupName: '$(AppServiceResourceGroup)'
                     location: 'East US'
@@ -142,7 +142,7 @@ stages:
                 steps:
                 - task: AzureWebApp@1
                   inputs:
-                    azureSubscription: '$(AzureServicePrincipalName)'
+                    azureSubscription: '$(AzureServiceConnectionName)'
                     appType: 'webAppLinux'
                     appName: '$(AppServiceName)'
                     deployToSlotOrASE: true
@@ -162,7 +162,7 @@ stages:
                 steps:
                 - task: AzureWebApp@1
                   inputs:
-                    azureSubscription: '$(AzureServicePrincipalName)'
+                    azureSubscription: '$(AzureServiceConnectionName)'
                     appType: 'webAppLinux'
                     appName: '$(AppServiceName)'
                     deployToSlotOrASE: true
@@ -182,7 +182,7 @@ stages:
                 steps:
                 - task: AzureWebApp@1
                   inputs:
-                    azureSubscription: '$(AzureServicePrincipalName)'
+                    azureSubscription: '$(AzureServiceConnectionName)'
                     appType: 'webAppLinux'
                     appName: '$(AppServiceName)'
                     deployToSlotOrASE: true
@@ -203,7 +203,7 @@ stages:
                 - task: AzureAppServiceManage@0
                   displayName: ''
                   inputs:
-                    azureSubscription: '$(AzureServicePrincipalName)'
+                    azureSubscription: '$(AzureServiceConnectionName)'
                     Action: 'Swap Slots'
                     WebAppName: '$(AppServiceName)'
                     ResourceGroupName: '$(AppServiceResourceGroup)'


### PR DESCRIPTION
This pull request includes changes to the `azure-build-and-release-pipeline.yml` file in the `azure/pipelines` directory. The changes are primarily focused on renaming the `AzureServicePrincipalName` variable to `AzureServiceConnectionName` and updating all its references in the pipeline stages. 

Here are the key changes:

* [`azure/pipelines/azure-build-and-release-pipeline.yml`](diffhunk://#diff-c042c5cc9bcfa797e88d18cf420bdcae1385306878dba835ecea536b5a8fbcd3L39-R40): Renamed the `AzureServicePrincipalName` variable to `AzureServiceConnectionName` in the `variables:` section.

Updates to pipeline stages:

* [`azure/pipelines/azure-build-and-release-pipeline.yml`](diffhunk://#diff-c042c5cc9bcfa797e88d18cf420bdcae1385306878dba835ecea536b5a8fbcd3L116-R116): Updated the `azureSubscription` in various tasks within the `stages:` section to use the new `AzureServiceConnectionName` variable. [[1]](diffhunk://#diff-c042c5cc9bcfa797e88d18cf420bdcae1385306878dba835ecea536b5a8fbcd3L116-R116) [[2]](diffhunk://#diff-c042c5cc9bcfa797e88d18cf420bdcae1385306878dba835ecea536b5a8fbcd3L125-R125) [[3]](diffhunk://#diff-c042c5cc9bcfa797e88d18cf420bdcae1385306878dba835ecea536b5a8fbcd3L145-R145) [[4]](diffhunk://#diff-c042c5cc9bcfa797e88d18cf420bdcae1385306878dba835ecea536b5a8fbcd3L165-R165) [[5]](diffhunk://#diff-c042c5cc9bcfa797e88d18cf420bdcae1385306878dba835ecea536b5a8fbcd3L185-R185) [[6]](diffhunk://#diff-c042c5cc9bcfa797e88d18cf420bdcae1385306878dba835ecea536b5a8fbcd3L206-R206)