### PR TITLE
Updated Azure subscription for pipeline

### DIFF
--- a/azure/arm/azure-appservice.parameters.json
+++ b/azure/arm/azure-appservice.parameters.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
       "subscriptionId": {
-          "value": "233779e9-4d8e-43ab-8c13-36b86d4386ca"
+          "value": "4ee742f0-2480-42d2-9f19-6bfccb45e4d4"
       },
       "name": {
           "value": "PWAWeatherApp"

--- a/azure/pipelines/azure-build-and-release-pipeline.yml
+++ b/azure/pipelines/azure-build-and-release-pipeline.yml
@@ -33,7 +33,7 @@ parameters:
 # See: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#environment-variables
 variables:
   - name: AzureSubscriptionId
-    value: '233779e9-4d8e-43ab-8c13-36b86d4386ca'
+    value: '4ee742f0-2480-42d2-9f19-6bfccb45e4d4'
     readonly: true
 
   - name: AzureServiceConnectionName


### PR DESCRIPTION
This pull request mainly involves changes to the Azure configuration files. The most significant change is the update of the Azure subscription ID in two files: `azure/arm/azure-appservice.parameters.json` and `azure/pipelines/azure-build-and-release-pipeline.yml`. 

Here are the key changes:

* [`azure/arm/azure-appservice.parameters.json`](diffhunk://#diff-7324f8638ef1babc7a0a81530e30621c2501ca1e4d1df4e967749f90fe0331aeL6-R6): The Azure subscription ID has been updated under the `parameters` section.
* [`azure/pipelines/azure-build-and-release-pipeline.yml`](diffhunk://#diff-c042c5cc9bcfa797e88d18cf420bdcae1385306878dba835ecea536b5a8fbcd3L36-R36): The Azure subscription ID has been updated in the `variables` section.

These changes ensure that the Azure resources are associated with the correct subscription ID.