### PR TITLE
Updated AppService config to use Node 20

### DIFF
--- a/azure/pipelines/azure-build-and-release-pipeline.yml
+++ b/azure/pipelines/azure-build-and-release-pipeline.yml
@@ -66,9 +66,9 @@ stages:
 
         steps:
         - task: NodeTool@0
-          displayName: 'Use Node 18.x'
+          displayName: 'Use Node 20.x'
           inputs:
-            versionSpec: 18.x
+            versionSpec: 20.x
 
         - script: |
             npm install -g @angular/cli


### PR DESCRIPTION
This pull request updates the Node.js version used in the Azure build and release pipeline from Node 18.x to Node 20.x.

* [`azure/pipelines/azure-build-and-release-pipeline.yml`](diffhunk://#diff-c042c5cc9bcfa797e88d18cf420bdcae1385306878dba835ecea536b5a8fbcd3L69-R71): Changed the `NodeTool` task to use Node.js version 20.x instead of 18.x, updating both the `displayName` and `versionSpec` fields.