### PR TITLE
Updated Node version for Azure AppService from 18 -> 20

### DIFF
--- a/azure/arm/azure-appservice.parameters.json
+++ b/azure/arm/azure-appservice.parameters.json
@@ -42,7 +42,7 @@
           "value": "0"
       },
       "linuxFxVersion": {
-          "value": "NODE|18-lts"
+          "value": "NODE|20-lts"
       },
       "startupCommand": {
           "value": "pm2 serve /home/site/wwwroot --no-daemon --spa"


### PR DESCRIPTION
This pull request updates the Node.js runtime version used in the Azure App Service deployment configuration.

* Deployment configuration update:
  * Changed the `linuxFxVersion` parameter in `azure/arm/azure-appservice.parameters.json` from `NODE|18-lts` to `NODE|20-lts` to use the latest Node.js LTS version for the application.